### PR TITLE
fix parsing empty query string

### DIFF
--- a/shared/src/main/scala/urldsl/vocabulary/Param.scala
+++ b/shared/src/main/scala/urldsl/vocabulary/Param.scala
@@ -14,7 +14,8 @@ object Param {
       .map(_.split("=").toList)
       .toList
       .collect {
-        case first :: second :: Nil => first -> second
+        case first :: Nil if first.nonEmpty => first -> ""
+        case first :: second :: Nil if first.nonEmpty => first -> second
       }
       .groupBy(_._1)
       .map { case (key, value) => key -> value.map(_._2) }


### PR DESCRIPTION
- bug: parsing empty query parameter like `http://localhost:8080?foo=`as String  returned None instead of Some("").
- improve: check if query parameter's key is valid. `http://localhost:8080?=value` was parsed into "" -> Param(value).